### PR TITLE
workaround type inference

### DIFF
--- a/src/checksums/private/sha_utils.nim
+++ b/src/checksums/private/sha_utils.nim
@@ -34,7 +34,7 @@ when defined(js):
           # simple.
           doAssert false
 
-        (lo: forceUnsigned x, hi: 0)
+        (lo: forceUnsigned x, hi: 0'u32)
       else:
         (lo: forceUnsigned x, hi: forceUnsigned(x shr 32))
 


### PR DESCRIPTION
There is no type inference for `when nimvm` expressions for now